### PR TITLE
Fix SimpleCondition Example Typo and argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ googleAscendPattern = Pattern(
         SimpleCondition(Variable("a", lambda x: x["Peak Price"]), 
                         Variable("b", lambda x: x["Peak Price"]),
                         Variable("c", lambda x: x["Peak Price"]),
-                        lambda x,y,z: x < b < z),
+                        relation_op=lambda x,y,z: x < y < z),
         timedelta(minutes=3)
     )
 ```


### PR DESCRIPTION
For SimpleCondition  the relational operator (relation_op) is a required named parameter - it is missing from the example.
Also the SimpleCondition example incorrectly uses the lambda function argument b instead of y (which is one of the arguments)